### PR TITLE
fix fsa assist interrupts fsa jump

### DIFF
--- a/ED_AP.py
+++ b/ED_AP.py
@@ -1039,9 +1039,6 @@ class EDAutopilot:
             sleep(16)
 
             if self.jn.ship_state()['status'] != 'starting_hyperspace':
-                logger.debug('jump= misalign stop fsd')
-                self.keys.send('HyperSuperCombination', hold=1)
-                sleep(2)
                 self.mnvr_to_target(scr_reg)  # attempt realign to target
             else:
                 logger.debug('jump= in jump')


### PR DESCRIPTION
I now have a few thousand jumps behind me with this AP and not even one miss align but these 3 lines unfortunately interrupt the fsa during the further jump attempts when the fsa is damaged. If a miss align should take place the fsa must not be interrupted that should not be a problem.