### PR TITLE
Feature/undock for supercruise

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,10 @@
+# 6/24/2024 Update
+ - Stumpii Added undocking if necessary to start of supercruise assist.
+
 # 6/23/2024 Targetting update
 - Stumpii provided change to Nav Offset to include Z axis where Z=+1 for target ahead and Z=-1 for target behind. Use the data to navigate to the target quicker when the target is behind us (pitch up or down depending if target is above/below us).
 
-# 8/6/23 latest mss libary causing crash
+# 8/6/23 latest mss library causing crash
 - if you are seeing:  AttributeError: '_thread._local' object has no attribute 'srcdc'   then you need to downgrade the mss library.  Updated the requirements.txt file accordingly
 - pip install mss==8.0.3
 

--- a/EDAPGui.py
+++ b/EDAPGui.py
@@ -195,27 +195,32 @@ class APGui():
         if key == 'log':
             self.log_msg(body)
         elif key == 'fsd_stop':
+            logger.debug("Detected 'fsd_stop' key")
             self.checkboxvar['FSD Route Assist'].set(0)
             self.check_cb('FSD Route Assist')
         elif key == 'fsd_start':
             self.checkboxvar['FSD Route Assist'].set(1)
             self.check_cb('FSD Route Assist')
         elif key == 'sc_stop':
+            logger.debug("Detected 'sc_stop' key")
             self.checkboxvar['Supercruise Assist'].set(0)
             self.check_cb('Supercruise Assist')
         elif key == 'sc_start':
             self.checkboxvar['Supercruise Assist'].set(1)
             self.check_cb('Supercruise Assist')
         elif key == 'waypoint_stop':
+            logger.debug("Detected 'waypoint_stop' key")
             self.checkboxvar['Waypoint Assist'].set(0)
             self.check_cb('Waypoint Assist')
         elif key == 'robigo_stop':
+            logger.debug("Detected 'robigo_stop' key")
             self.checkboxvar['Robigo Assist'].set(0)
             self.check_cb('Robigo Assist')
         elif key == 'robigo_start':
             self.checkboxvar['Robigo Assist'].set(1)
             self.check_cb('Robigo Assist')
         elif key == 'afk_stop':
+            logger.debug("Detected 'afk_stop' key")
             self.checkboxvar['AFK Combat Assist'].set(0)
             self.check_cb('AFK Combat Assist')
         elif key == 'jumpcount':
@@ -244,9 +249,11 @@ class APGui():
         messagebox.showinfo('Mouse XY', 'Values: ' + xy_str + '\n has been place in your clipboard')
 
     def quit(self):
+        logger.debug("Entered: quit")
         self.close_window()
 
     def close_window(self):
+        logger.debug("Entered: close_window")
         self.stop_fsd()
         self.stop_sc()
         self.ed_ap.quit()
@@ -255,6 +262,7 @@ class APGui():
 
     # this routine is to stop any current autopilot activity
     def stop_all_assists(self):
+        logger.debug("Entered: stop_all_assists")
         self.callback('fsd_stop')
         self.callback('sc_stop')
         self.callback('afk_stop')
@@ -262,44 +270,56 @@ class APGui():
         self.callback('robigo_stop')
 
     def start_fsd(self):
+        logger.debug("Entered: start_fsd")
         self.ed_ap.set_fsd_assist(True)
         self.FSD_A_running = True
         self.log_msg("FSD Route Assist start")
 
     def stop_fsd(self):
+        logger.debug("Entered: stop_fsd")
         self.ed_ap.set_fsd_assist(False)
         self.FSD_A_running = False
         self.log_msg("FSD Route Assist stop")
+        self.update_statusline("Idle")
 
     def start_sc(self):
+        logger.debug("Entered: start_sc")
         self.ed_ap.set_sc_assist(True)
         self.SC_A_running = True
         self.log_msg("SC Assist start")
 
     def stop_sc(self):
+        logger.debug("Entered: stop_sc")
         self.ed_ap.set_sc_assist(False)
         self.SC_A_running = False
         self.log_msg("SC Assist stop")
+        self.update_statusline("Idle")
 
     def start_waypoint(self):
+        logger.debug("Entered: start_waypoint")
         self.ed_ap.set_waypoint_assist(True)
         self.WP_A_running = True
         self.log_msg("Waypoint Assist start")
 
     def stop_waypoint(self):
+        logger.debug("Entered: stop_waypoint")
         self.ed_ap.set_waypoint_assist(False)
         self.WP_A_running = False
         self.log_msg("Waypoint Assist stop")
+        self.update_statusline("Idle")
 
     def start_robigo(self):
+        logger.debug("Entered: start_robigo")
         self.ed_ap.set_robigo_assist(True)
         self.RO_A_running = True
         self.log_msg("Robigo Assist start")
 
     def stop_robigo(self):
+        logger.debug("Entered: stop_robigo")
         self.ed_ap.set_robigo_assist(False)
         self.RO_A_running = False
         self.log_msg("Robigo Assist stop")
+        self.update_statusline("Idle")
 
     def about(self):
         webbrowser.open_new("https://github.com/SumZer0-git/EDAPGui")
@@ -756,6 +776,7 @@ class APGui():
         return mylist
 
     def restart_program(self):
+        logger.debug("Entered: restart_program")
         print("restart now")
 
         self.stop_fsd()

--- a/ED_AP.py
+++ b/ED_AP.py
@@ -1226,7 +1226,7 @@ class EDAutopilot:
         if dest != "" and self.jn.ship_state()['status'] == 'in_station':
             self.waypoint_undock_seq()
 
-            # if we are in space but not in supercruise, get into supercruise
+        # if we are in space but not in supercruise, get into supercruise
         if self.jn.ship_state()['status'] != 'in_supercruise':
             self.sc_engage()
 

--- a/ED_AP.py
+++ b/ED_AP.py
@@ -1352,6 +1352,11 @@ class EDAutopilot:
             logger.debug("Quiting sc_assist - compass not found")
             return
 
+        # if we are starting the waypoint docked at a station, we need to undock first
+        if self.jn.ship_state()['status'] == 'in_station':
+            self.update_overlay()
+            self.waypoint_undock_seq()
+
         # if we are in space but not in supercruise, get into supercruise
         if self.jn.ship_state()['status'] != 'in_supercruise':
             self.sc_engage()

--- a/ED_AP.py
+++ b/ED_AP.py
@@ -520,9 +520,10 @@ class EDAutopilot:
         else:
             return False
 
-    # Determine how far off we are from the destination being in the middle of the screen (in this case the specified region
-    #
     def get_destination_offset(self, scr_reg):
+        """ Determine how far off we are from the target being in the middle of the screen
+        (in this case the specified region). """
+
         threshold = 0.54
         dst_image, (minVal, maxVal, minLoc, maxLoc), match = scr_reg.match_template_in_region('target', 'target')
 
@@ -755,7 +756,6 @@ class EDAutopilot:
             logger.error('align=err1')
             raise Exception('nav_align not in super or space')
 
-        self.keys.send('SetSpeed50')
         self.vce.say("Navigation Align")
 
         # get the x,y offset from center, or none, which means our point is behind us
@@ -763,7 +763,6 @@ class EDAutopilot:
 
         # check to see if we are already converged, if so return    
         if off['z'] > 0 and abs(off['x']) < close and abs(off['y']) < close:
-            self.keys.send('SetSpeed100')
             return
 
         # nav point must be behind us, pitch up until somewhat in front of us
@@ -776,7 +775,6 @@ class EDAutopilot:
 
         # check if converged, unlikely at this point
         if off['z'] > 0 and abs(off['x']) < close and abs(off['y']) < close:
-            self.keys.send('SetSpeed100')
             return
 
         # try multiple times to get aligned.  If the sun is shining on console, this it will be hard to match
@@ -785,7 +783,6 @@ class EDAutopilot:
             off = self.get_nav_offset(scr_reg)
 
             if off['z'] > 0 and abs(off['x']) < close and abs(off['y']) < close:
-                self.keys.send('SetSpeed100')
                 break
 
             while off['z'] < 0:
@@ -844,8 +841,6 @@ class EDAutopilot:
                 pass
             sleep(.1)
             logger.debug("final x:"+str(off['x'])+" y:"+str(off['y']))
-
-        self.keys.send('SetSpeed100')
 
     def target_align(self, scr_reg):
         """ Coarse align to the target to support FSD jumping """
@@ -940,7 +935,7 @@ class EDAutopilot:
 
         # Could not be found, return
         if off == None:
-            print("sc_target_align not finding")
+            logger.debug("sc_target_align not finding target")
             self.ap_ckb('log', 'Target not found, terminating SC Assist')
             return False
 
@@ -979,6 +974,13 @@ class EDAutopilot:
             new = self.get_destination_offset(scr_reg)
             if new:
                 off = new
+
+            # Check if target is outside the target region (behind us) and break loop
+            if new == None:
+                logger.debug("sc_target_align lost target")
+                self.ap_ckb('log', 'Target lost, attempting re-alignment.')
+                return False
+
         return True
 
     # Reposition is use when the target is obscured by a world
@@ -1371,18 +1373,23 @@ class EDAutopilot:
 
         # Loop forever keeping tight align to target, until we get SC Disengage popup
         while True:
-            self.keys.send('SetSpeed50')
             sleep(0.05)
 
             if self.jn.ship_state()['status'] == 'in_supercruise':
+
+                # Align and stay on target. If false is returned, we have lost the target behind us.
                 if self.sc_target_align(scr_reg) == False:
-                    self.nav_align(scr_reg)
+                    # Continue ahead before aligning to prevent us circling the target
+                    self.keys.send('SetSpeed100')
+                    sleep(5)
+                    self.keys.send('SetSpeed50')
+                    self.nav_align(scr_reg) # Align to target
             else:
                 # if we dropped from SC, then we rammed into planet
                 align_failed = True
                 break
 
-                # check if we are being interdicted, means we saw it on screen or we already got interdicted
+            # check if we are being interdicted, means we saw it on screen or we already got interdicted
             if self.being_interdicted(scr_reg) == True or self.jn.ship_state()['interdicted'] == True:
 
                 self.keys.send('SetSpeedZero')  # submit


### PR DESCRIPTION
- Added undocking if necessary to start of supercruise assist.
- Removed speed demands from the nav alignment code. Nav align should just do the alignment, the calling function determine what to do if alignment is successful or not. All but one of the calling routines sets the speed after calling the routine anyway.
- sc_assist no longer spams 50% speed every iteration of its loop. So pilot is free to control the speed and just let AP do the alignment. Works great for manual 75% throttle at 0:07 from target and when using new SCO in SC.
- sc_target_align now returns false if the target was found and now is lost and as no other cause was captured, then we went past the target.
- While in SC, if we fly past the target, keep going for 5 secs, then slow to 50% and turn around using nav_align.