### PR TITLE
Added configs for Python Mk2 and Type-8. Added option to refocus Elite client window before each new key press.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# 8/17/2024 New ships and auto focus
+ - Stumpii: Added configs for the two new ships (Python Mk2 and Type-8).
+ - Stumpii: Added option to refocus Elite client window before each new key press to avoid sending keys to an unwanted window.
+
 # 6/24/2024 Update
  - Stumpii: Added undocking if necessary to start of supercruise assist.
  - Stumpii: Removed speed demands from the nav alignment code. Nav align should just do the alignment, the calling function determine what to do if alignment is successful or not. All but one of the calling routines sets the speed after calling the routine anyway.

--- a/EDAPGui.py
+++ b/EDAPGui.py
@@ -79,8 +79,8 @@ class APGui():
             'ELW Scanner': "Will perform FSS scans while FSD Assist is traveling between stars. \nIf the FSS shows a signal in the region of Earth, \nWater or Ammonia type worlds, it will announce that discovery.",
             'AFK Combat Assist': "Used with a AFK Combat ship in a Rez Zone.",
             'RollRate': "Roll rate your ship has.",
-            'PitchRate': "Pitch rate your ship has.",
-            'YawRate': "Yaw rate your ship has.",
+            'PitchRate': "Pitch (up/down) rate your ship has.",
+            'YawRate': "Yaw rate (rudder) your ship has.",
             'SunPitchUp+Time': "This field are for ship that tend to overheat. \nProviding 1-2 more seconds of Pitch up when avoiding the Sun \nwill overcome this problem.",
             'Sun Bright Threshold': "The low level for brightness detection, \nrange 0-255, want to mask out darker items",
             'Nav Align Tries': "How many attempts the ap should make at alignment.",
@@ -122,6 +122,7 @@ class APGui():
         self.msgList = self.gui_gen(root)
 
         self.checkboxvar['Enable Randomness'].set(self.ed_ap.config['EnableRandomness'])
+        self.checkboxvar['Activate Elite for each key'].set(self.ed_ap.config['ActivateEliteEachKey'])
         self.checkboxvar['Enable Overlay'].set(self.ed_ap.config['OverlayTextEnable'])
         self.checkboxvar['Enable Voice'].set(self.ed_ap.config['VoiceEnable'])
 
@@ -555,6 +556,13 @@ class APGui():
         else:
             self.ed_ap.set_randomness(False)
 
+        if self.checkboxvar['Activate Elite for each key'].get():
+            self.ed_ap.set_activate_elite_eachkey(True)
+            self.ed_ap.keys.activate_window=True
+        else:
+            self.ed_ap.set_activate_elite_eachkey(False)
+            self.ed_ap.keys.activate_window = False
+
         if self.checkboxvar['Enable Overlay'].get():
             self.ed_ap.set_overlay(True)
         else:
@@ -716,6 +724,9 @@ class APGui():
         self.checkboxvar['Enable Randomness'] = BooleanVar()
         cb_random = Checkbutton(blk_ap, text='Enable Randomness', anchor='w', pady=3, justify=LEFT, onvalue=1, offvalue=0, variable=self.checkboxvar['Enable Randomness'], command=(lambda field='Enable Randomness': self.check_cb(field)))
         cb_random.grid(row=4, column=0, columnspan=2, sticky=(W))
+        self.checkboxvar['Activate Elite for each key'] = BooleanVar()
+        cb_random = Checkbutton(blk_ap, text='Activate Elite for each key', anchor='w', pady=3, justify=LEFT, onvalue=1, offvalue=0, variable=self.checkboxvar['Activate Elite for each key'], command=(lambda field='Activate Elite for each key': self.check_cb(field)))
+        cb_random.grid(row=5, column=0, columnspan=2, sticky=(W))
 
         # buttons settings block
         blk_buttons = LabelFrame(blk_settings, text="BUTTONS")

--- a/EDKeys.py
+++ b/EDKeys.py
@@ -3,6 +3,8 @@ from os.path import abspath, getmtime, isfile, join
 from time import sleep, time
 from xml.etree.ElementTree import parse
 
+import win32gui
+
 from directinput import *
 from EDlogger import logger
 
@@ -18,6 +20,15 @@ Constraints:  This file will use the latest modified *.binds file
 
 Author: sumzer0@yahoo.com
 """
+
+
+def set_focus_elite_window():
+    """ set focus to the ED window, if ED does not have focus then the keystrokes will go to the window
+    that does have focus. """
+    handle = win32gui.FindWindow(0, "Elite - Dangerous (CLIENT)")
+    if handle != 0:
+        win32gui.SetForegroundWindow(handle)  # give focus to ED
+
 
 class EDKeys:
 
@@ -62,6 +73,7 @@ class EDKeys:
             'Supercruise'
         ]
         self.keys = self.get_bindings(self.keys_to_obtain)
+        self.activate_window = False
 
         # dump config to log
         for key in self.keys_to_obtain:
@@ -149,6 +161,11 @@ class EDKeys:
         return latest_bindings
 
     def send_key(self, type, key):
+        # Focus Elite window if configured
+        if self.activate_window:
+            set_focus_elite_window()
+            sleep(0.05)
+
         if type == 'Up':
             ReleaseKey(key)
         else:
@@ -162,6 +179,10 @@ class EDKeys:
 
         logger.debug('send=key:'+str(key)+',hold:'+str(hold)+',repeat:'+str(repeat)+',repeat_delay:'+str(repeat_delay)+',state:'+str(state))
         for i in range(repeat):
+            # Focus Elite window if configured.
+            if self.activate_window:
+                set_focus_elite_window()
+                sleep(0.05)
 
             if state is None or state == 1:
                 if 'mod' in key:
@@ -187,6 +208,7 @@ class EDKeys:
                 sleep(repeat_delay)
             else:
                 sleep(self.key_repeat_delay)
+
 
 def main():
     k = EDKeys()

--- a/ED_AP.py
+++ b/ED_AP.py
@@ -55,6 +55,7 @@ class EDAutopilot:
             "HotKey_StopAllAssists": "end",
             "Robigo_Single_Loop": False,   # True means only 1 loop will executed and then terminate the Robigo, will not perform mission processing
             "EnableRandomness": False,     # add some additional random sleep times to avoid AP detection (0-3sec at specific locations)
+            "ActivateEliteEachKey": False, # Activate Elite window before each key or group of keys
             "OverlayTextEnable": False,    # Experimental at this stage
             "OverlayTextYOffset": 400,     # offset down the screen to start place overlay text
             "OverlayTextXOffset": 50,      # offset left the screen to start place overlay text
@@ -403,7 +404,6 @@ class EDAutopilot:
 
     def have_destination(self, scr_reg) -> bool:
         """ Check to see if the compass is on the screen. """
-
         icompass_image, (minVal, maxVal, minLoc, maxLoc), match = scr_reg.match_template_in_region('compass', 'compass')
 
         logger.debug("has_destination:"+str(maxVal))
@@ -692,7 +692,7 @@ class EDAutopilot:
                 if self.jn.ship_state()['status'] == "in_station":
                     # go to top item, select (which should be refuel)
                     self.keys.send('UI_Up', hold=3)
-                    self.keys.send('UI_Select') # Refuel
+                    self.keys.send('UI_Select')  # Refuel
                     sleep(0.5)
                     self.keys.send('UI_Right')  # Repair
                     self.keys.send('UI_Select')
@@ -1514,6 +1514,9 @@ class EDAutopilot:
 
     def set_randomness(self, enable=False):
         self.config["EnableRandomness"] = enable
+
+    def set_activate_elite_eachkey(self, enable=False):
+        self.config["ActivateEliteEachKey"] = enable
 
     def set_overlay(self, enable=False):
         # TODO: apply the change without restarting the program

--- a/Screen_Regions.py
+++ b/Screen_Regions.py
@@ -32,7 +32,7 @@ class Screen_Regions:
         self.reg['target']    = {'rect': [0.33, 0.27, 0.66, 0.70], 'width': 1, 'height': 1, 'filterCB': self.filter_by_color, 'filter': self.orange_2_color_range}   # also called destination
         self.reg['target_occluded']    = {'rect': [0.33, 0.27, 0.66, 0.70], 'width': 1, 'height': 1, 'filterCB': self.filter_by_color, 'filter': self.target_occluded_range} 
         self.reg['sun']       = {'rect': [0.30, 0.30, 0.70, 0.68], 'width': 1, 'height': 1, 'filterCB': self.filter_sun, 'filter': None}
-        self.reg['disengage'] = {'rect': [0.42, 0.70, 0.60, 0.80], 'width': 1, 'height': 1, 'filterCB': self.filter_by_color, 'filter': self.blue_color_range} 
+        self.reg['disengage'] = {'rect': [0.42, 0.65, 0.60, 0.80], 'width': 1, 'height': 1, 'filterCB': self.filter_by_color, 'filter': self.blue_color_range}
         self.reg['interdicted'] = {'rect': [0.60, 0.1, 0.90, 0.25], 'width': 1, 'height': 1, 'filterCB': self.filter_by_color, 'filter': self.orange_2_color_range}
         self.reg['fss']       = {'rect': [0.5045, 0.7545, 0.532, 0.7955], 'width': 1, 'height': 1, 'filterCB': self.equalize, 'filter': None}
         self.reg['mission_dest']  = {'rect': [0.46, 0.38, 0.65, 0.86], 'width': 1, 'height': 1, 'filterCB': self.equalize, 'filter': None}    

--- a/ships/python-mk2.json
+++ b/ships/python-mk2.json
@@ -1,0 +1,1 @@
+{"rollrate": 90.0, "pitchrate": 19.0, "yawrate": 11.0, "SunPitchUp+Time": 0.0}

--- a/ships/type-8.json
+++ b/ships/type-8.json
@@ -1,0 +1,1 @@
+{"rollrate": 60.0, "pitchrate": 16.0, "yawrate": 9.0, "SunPitchUp+Time": 0.0}


### PR DESCRIPTION
1. Added configs for the two new ships (Python Mk2 and Type-8).
Increased 'disengage' region as text appears higher in the Python Mk2 and is cut off in current region.

2. Added option to refocus Elite client window before each new key press to avoid sending keys to an unwanted window.
